### PR TITLE
Fix bound conflict with Skript

### DIFF
--- a/src/tk/shanebee/nbt/elements/expressions/ExprBoundCoords.java
+++ b/src/tk/shanebee/nbt/elements/expressions/ExprBoundCoords.java
@@ -29,7 +29,7 @@ public class ExprBoundCoords extends PropertyExpression<Bound, Object> {
         Skript.registerExpression(ExprBoundCoords.class, Object.class, ExpressionType.PROPERTY,
                 "lesser (0¦x|1¦y|2¦z) coord[inate] of [bound] %bound%",
                 "greater (0¦x|1¦y|2¦z) coord[inate] of [bound] %bound%",
-                "world of [bound] %bound%");
+                "world of bound %bound%");
     }
 
     private boolean WORLD;


### PR DESCRIPTION
```vb
function getBlocks(loc1: location, loc2: location) :: Objects:
    set {_x1} to x coord of {_loc1}
    set {_y1} to y coord of {_loc1}
    set {_z1} to z coord of {_loc1}
    set {_x2} to x coord of {_loc2}
    set {_y2} to y coord of {_loc2}
    set {_z2} to z coord of {_loc2}
    loop numbers between {_z1} and {_z2}:
        loop numbers between {_y1} and {_y2}:
            loop numbers between {_x1} and {_x2}:
                add location(loop-numbers-3, loop-numbers-2, loop-numbers-1, world of {_loc1}) to {_locs::*}
    return {_locs::*}
```

This code works without the Sk-NBeeT, but it gives a console error with latest Sk-NBeeT. It works with Sk-NBeeT 2.5.0 or older, but not newer because of this bound system. I did not test the changes but I think it fixes it.

This the location function used (from Skript itself).
https://github.com/SkriptLang/Skript/blob/2.4-beta9/src/main/java/ch/njol/skript/classes/data/DefaultFunctions.java#L310

This the world of bound thing conflicting:
![image](https://user-images.githubusercontent.com/24778409/68535391-20761580-0353-11ea-9d00-c162f1edb41c.png)

This the whole error if you interested:
![image](https://user-images.githubusercontent.com/24778409/68535397-3b488a00-0353-11ea-8729-f9e88abe6b9a.png)
![image](https://user-images.githubusercontent.com/24778409/68535398-3f74a780-0353-11ea-8170-11fb2abde5b8.png)
![image](https://user-images.githubusercontent.com/24778409/68535401-48657900-0353-11ea-83af-f83f8470a0ac.png)

I think the problem is in the ExprBoundCoords class. I think the pattern world of [bound] %bound% is the problem. The bound should **not** be optional because Skript already has a world of %location% thingy.

This may break some code that uses bound system without explicit world of bound syntax, so it should be noted in release notes, if merged. Please review and test changes, I have not much time.

**Disclaimer and Note**: I did not take these screenshots and the code I given is not my code. A people in the Discord faced this problem, with a quick search I found this conflict and told him to downgrade into 2.5.0, and it fixed it. He said it already works without Sk-NBeeT, so problem is in Sk-NBeeT.